### PR TITLE
Update URL to https

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ description: Math, Data, Machine learning, Chemical engineering
 logo: cover.jpeg
 search: true
  # url: http://localhost:4000
-url: http://CorySimon.github.io
+url: https://CorySimon.github.io
 
 # Jekyll configuration
 


### PR DESCRIPTION
Github.io redirects to the https version automatically and it breaks the stylesheet.